### PR TITLE
docs(examples): production DR example with restore-to-latest and PITR (#213)

### DIFF
--- a/examples/production-dr/.gitignore
+++ b/examples/production-dr/.gitignore
@@ -1,0 +1,2 @@
+.last-accident-time
+docker-compose.override.yml

--- a/examples/production-dr/Dockerfile
+++ b/examples/production-dr/Dockerfile
@@ -1,0 +1,15 @@
+# PostgreSQL image with the pgrwl binary inside.
+#
+# The restore path needs `pgrwl` in the same container as PostgreSQL:
+#   - `pgrwl restore` writes the base backup into PGDATA
+#   - `restore_command = 'pgrwl restore-command ...'` fetches WAL during recovery
+#
+# The binary comes from the GitHub release for the container's architecture,
+# so the image builds the same way on amd64 and arm64 hosts.
+ARG PG_IMAGE=postgres:17.9-bookworm
+FROM ${PG_IMAGE}
+
+ARG PGRWL_VERSION=1.0.39
+ARG TARGETARCH
+ADD https://github.com/pgrwl/pgrwl/releases/download/v${PGRWL_VERSION}/pgrwl_v${PGRWL_VERSION}_linux_${TARGETARCH}.tar.gz /tmp/pgrwl.tgz
+RUN tar -xzf /tmp/pgrwl.tgz -C /usr/local/bin pgrwl && rm -f /tmp/pgrwl.tgz && pgrwl --version

--- a/examples/production-dr/README.md
+++ b/examples/production-dr/README.md
@@ -1,0 +1,129 @@
+# Production-style disaster recovery with pgrwl
+
+A small, complete backup-and-restore setup you can run on a laptop and repeat on a server:
+PostgreSQL 17, `pgrwl` streaming WAL and base backups to S3 (SeaweedFS here), and two
+rehearsed recoveries: **restore to the latest transaction** after losing the data directory,
+and **point-in-time recovery** to just before an accidental `DROP TABLE`.
+
+Everything happens with `pgrwl` commands only: no `pg_basebackup`, no renaming of `.partial`
+files, no hand-written `restore_command` wrappers.
+
+```
+pg-primary       PostgreSQL 17 + the pgrwl binary (Dockerfile)      normal operation
+pgrwl-receive    streams WAL, uploads segments and base backups      normal operation
+seaweedfs        S3-compatible storage, one container                normal operation
+pgrwl-serve      serves WAL to the recovering PostgreSQL             restore only
+pg-restore       one-shot: base backup -> PGDATA, recovery settings  restore only
+```
+
+Requirements: Docker Compose v2, `curl`. On an arm64 host uncomment the `platform:` lines in
+`docker-compose.yml` (the `quay.io/pgrwl/pgrwl` image is published for amd64 only).
+
+## 1. Start and take the first base backup
+
+```bash
+docker compose up -d --build
+scripts/01-backup.sh          # pgrwl backup, then lists backups from http://localhost:7070/api/v1/backups
+scripts/02-workload.sh 30     # one timestamped row per second into dr_events, so restores are checkable
+```
+
+Order matters: the receiver starts first (compose does that), the base backup comes second. The
+receiver creates the replication slot, and the slot is what makes PostgreSQL keep every WAL record
+from the backup's start LSN (`wal_start_lsn` in the API output) until the receiver has it. A base
+backup taken before the slot exists can lose the WAL it needs. The receiver keeps streaming while
+the backup runs.
+
+## 2. Scenario A: the data directory is gone
+
+```bash
+scripts/04-restore-latest.sh
+```
+
+What the script does, in order:
+
+1. stops `pg-primary` and `pgrwl-receive`, deletes the `pg-data` volume (this is the disaster)
+2. starts `pgrwl-serve`: PostgreSQL will pull WAL from it during recovery
+3. runs `pg-restore`: `pgrwl restore` writes the newest base backup into the empty PGDATA,
+   creates `recovery.signal` and a `postgresql.auto.conf` with
+   `restore_command = 'pgrwl restore-command --serve-addr=pgrwl-serve:7070 %f %p'`
+4. starts `pg-primary`: archive recovery replays every WAL file the archive has, then promotes
+5. starts `pgrwl-receive` again and stops `pgrwl-serve`
+
+Expected output: `recovered to timeline 2 in Ns` and the same row count `dr_events` had before.
+
+## 3. Scenario B: someone dropped a table
+
+```bash
+scripts/01-backup.sh                 # optional; any earlier backup works too
+scripts/02-workload.sh 15
+scripts/03-accident.sh               # prints T, then DROP TABLE dr_events
+scripts/05-restore-pitr.sh "<T>"     # T exactly as printed, e.g. "2026-09-09 10:15:30.123456+00"
+```
+
+Same five steps as scenario A, with two differences:
+
+- the base backup is chosen for you: the newest one whose `finished` time precedes T
+  (from `/api/v1/backups`; pass an id as the second argument to choose yourself)
+- `pg-restore` adds `recovery_target_time = '<T>'` and `recovery_target_action = 'promote'`
+
+Expected output: the table is back, `rows after T (must be 0): 0`, and PostgreSQL's log shows
+`recovery stopping before commit of transaction N` for the transaction that dropped the table.
+
+The scripts restore in place for brevity. On a real system, run scenario B on a separate instance
+(or a copy of the data directory), take what you need from it, and leave the production cluster
+alone: everything committed after T is gone on the restored copy.
+
+## 4. After any restore
+
+- The cluster is on a **new timeline**. The receiver notices, follows the timeline switch and
+  recreates its replication slot; check `docker compose logs pgrwl-receive` for
+  `end of timeline, continue`.
+- Take a **new base backup** (`scripts/01-backup.sh`). Backups taken before the restore remain
+  usable for the old timeline only.
+- Retention is disabled in this example so you can rehearse freely. In production set
+  `receiver.retention` to the recovery window you need.
+
+## 5. What you can lose
+
+`pgrwl` uploads a WAL segment when it is complete; the segment being written lives on the
+receiver's volume (`pgrwl-data`) until then. `pgrwl-serve` reads that volume first, so as long as
+the receiver's disk survives, recovery reaches the last committed transaction. If the receiver
+host is lost together with the database, recovery uses S3 alone and stops at the last **completed**
+segment. Measured here: after `SELECT pg_switch_wal()` and the 10 s upload interval, every row written
+afterwards was lost; everything before it was recovered. To rehearse it:
+
+```bash
+docker compose --profile restore rm -sf pgrwl-receive pgrwl-serve
+docker volume rm production-dr_pgrwl-data
+scripts/04-restore-latest.sh
+```
+
+Keep the receiver's volume on durable storage, and bound the exposure with `archive_timeout`
+(for example `archive_timeout = 60s`): PostgreSQL then switches to a new segment at least that
+often, even with `archive_mode = off`, so the receiver can upload it. Each switch costs one 16 MiB
+segment in the archive (compressed by `pgrwl`).
+
+## 6. The same steps on a VM
+
+| Step | Container | VM |
+|---|---|---|
+| WAL source for recovery | `pgrwl-serve` service | `pgrwl daemon -m serve -c pgrwl.yaml` on the host that has the archive |
+| Base backup into PGDATA | `pg-restore` service | `pgrwl restore -c pgrwl.yaml --dest=$PGDATA [--id=ID]` |
+| Recovery settings | written by `restore.sh` | `touch $PGDATA/recovery.signal`, `restore_command`, optional `recovery_target_*` in `postgresql.auto.conf` |
+| Start and wait | `docker compose up -d pg-primary` | `pg_ctl start`, wait for `pg_is_in_recovery() = false` |
+
+`restore.sh` is intentionally short; read it once and the container-specific part is over.
+
+## Troubleshooting
+
+- `recovery ended before configured recovery target was reached`: either the chosen base backup
+  finished after T (pick an older id from `curl localhost:7070/api/v1/backups` and pass it as the
+  second argument), or T is later than the last WAL in the archive (use `04-restore-latest.sh`).
+- `invalid value for parameter "recovery_target_time"`: use PostgreSQL's own format,
+  `YYYY-MM-DD HH:MM:SS.US+00`; `T`/`Z` ISO variants are rejected.
+- `refusing to restore: PGDATA is not empty`: the `pg-data` volume still exists; the scripts delete
+  it first, on a VM move the old directory aside.
+- `no manifest file (*<id>.json*) found for backup <id>`: the newest backup was still running when
+  the disaster happened. Pass the previous id with `--id` (`RESTORE_ID=<id> scripts/04-restore-latest.sh`).
+- Backup ids are UTC start times (`YYYYMMDDHHMMSS`). If the receiver is down and the API is not
+  available, `pgrwl restore` without `--id` takes the newest backup.

--- a/examples/production-dr/docker-compose.yml
+++ b/examples/production-dr/docker-compose.yml
@@ -1,0 +1,208 @@
+# Production-style disaster recovery example for pgrwl.
+#
+# Normal operation (default profile):
+#   pg-primary      PostgreSQL 17 (+ pgrwl binary, see Dockerfile)
+#   pgrwl-receive   streams WAL, uploads segments and base backups to S3
+#   seaweedfs       S3-compatible object storage (single container)
+#
+# Recovery (profile "restore", started by scripts/04-* and 05-*):
+#   pgrwl-serve     serves WAL to the recovering PostgreSQL (local dir first, then S3)
+#   pg-restore      one-shot: pulls the base backup into PGDATA and writes recovery settings
+#
+# Endpoints on the host:
+#   PostgreSQL   psql "postgres://postgres:postgres@localhost:15432/postgres"
+#   pgrwl API    http://localhost:7070/api/v1/backups
+#   S3 API       http://localhost:8333 (access key: pgrwl / pgrwl-secret)
+
+services:
+  pg-primary:
+    image: pgrwl-production-dr/postgres-pgrwl:17.9
+    build:
+      context: .
+      args:
+        PG_IMAGE: postgres:17.9-bookworm
+        PGRWL_VERSION: "1.0.39"
+    container_name: pg-primary
+    restart: unless-stopped
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres
+    command: >
+      -c config_file=/etc/postgresql/postgresql.conf
+      -c hba_file=/etc/postgresql/pg_hba.conf
+    ports:
+      - "15432:5432"
+    volumes:
+      - pg-data:/var/lib/postgresql/data
+    configs:
+      - source: postgresql.conf
+        target: /etc/postgresql/postgresql.conf
+      - source: pg_hba.conf
+        target: /etc/postgresql/pg_hba.conf
+    healthcheck:
+      test: ["CMD", "pg_isready", "-U", "postgres"]
+      interval: 2s
+      timeout: 2s
+      retries: 15
+
+  pgrwl-receive:
+    image: quay.io/pgrwl/pgrwl:1.0.39
+    # platform: linux/amd64   # uncomment on arm64 hosts: the image is published for amd64 only
+    container_name: pgrwl-receive
+    restart: unless-stopped
+    environment:
+      PGHOST: pg-primary
+      PGPORT: 5432
+      PGUSER: postgres
+      PGPASSWORD: postgres
+    command: daemon -c /etc/pgrwl-config.yaml -m receive
+    ports:
+      - "7070:7070"
+    volumes:
+      - pgrwl-data:/mnt
+    configs:
+      - source: pgrwl-config.yaml
+        target: /etc/pgrwl-config.yaml
+    depends_on:
+      pg-primary:
+        condition: service_healthy
+      seaweedfs-provision:
+        condition: service_completed_successfully
+
+  seaweedfs:
+    image: chrislusf/seaweedfs:4.21
+    container_name: seaweedfs
+    restart: unless-stopped
+    command:
+      - server
+      - -s3
+      - -dir=/data
+      - -ip=seaweedfs
+      - -ip.bind=0.0.0.0
+      - -master.port=9333
+      - -volume.port=8080
+      - -filer.port=8888
+      - -s3.port=8333
+      - -s3.config=/etc/seaweedfs/s3.json
+    ports:
+      - "8333:8333"
+    volumes:
+      - seaweedfs-data:/data
+    configs:
+      - source: seaweedfs-s3.json
+        target: /etc/seaweedfs/s3.json
+    healthcheck:
+      test: ["CMD", "wget", "-q", "-O", "-", "http://127.0.0.1:8888/"]
+      interval: 3s
+      timeout: 2s
+      retries: 40
+
+  seaweedfs-provision:
+    image: chrislusf/seaweedfs:4.21
+    container_name: seaweedfs-provision
+    restart: "no"
+    entrypoint: ["/bin/sh", "-ec"]
+    command:
+      - |
+        until echo "cluster.ps" | weed shell -master=seaweedfs:9333 -filer=seaweedfs:8888 >/dev/null 2>&1; do sleep 2; done
+        echo "s3.bucket.create -name backups" | weed shell -master=seaweedfs:9333 -filer=seaweedfs:8888 || true
+        echo "s3.bucket.list" | weed shell -master=seaweedfs:9333 -filer=seaweedfs:8888
+    depends_on:
+      seaweedfs:
+        condition: service_healthy
+
+  # ---------------------------------------------------------------- restore profile
+
+  pgrwl-serve:
+    image: quay.io/pgrwl/pgrwl:1.0.39
+    # platform: linux/amd64   # see pgrwl-receive
+    container_name: pgrwl-serve
+    profiles: ["restore"]
+    command: daemon -c /etc/pgrwl-config.yaml -m serve
+    volumes:
+      - pgrwl-data:/mnt
+    configs:
+      - source: pgrwl-config.yaml
+        target: /etc/pgrwl-config.yaml
+
+  pg-restore:
+    image: pgrwl-production-dr/postgres-pgrwl:17.9
+    container_name: pg-restore
+    profiles: ["restore"]
+    restart: "no"
+    entrypoint: ["/bin/bash", "/restore.sh"]
+    environment:
+      # RESTORE_ID:            base backup id (UTC, YYYYMMDDHHMMSS); empty = latest
+      # RECOVERY_TARGET_TIME:  PostgreSQL timestamp, e.g. 2026-09-09 10:15:30.123456+00; empty = end of WAL
+      RESTORE_ID: ${RESTORE_ID:-}
+      RECOVERY_TARGET_TIME: ${RECOVERY_TARGET_TIME:-}
+    volumes:
+      - pg-data:/var/lib/postgresql/data
+    configs:
+      - source: pgrwl-config.yaml
+        target: /etc/pgrwl-config.yaml
+      - source: restore.sh
+        target: /restore.sh
+
+volumes:
+  pg-data:
+  pgrwl-data:
+  seaweedfs-data:
+
+configs:
+  postgresql.conf:
+    content: |
+      listen_addresses      = '*'
+      wal_level             = replica
+      max_wal_senders       = 10
+      max_replication_slots = 10
+      timezone              = 'UTC'
+      log_timezone          = 'UTC'
+      log_min_messages      = 'WARNING'
+      log_line_prefix       = '%t [%p] '
+
+  pg_hba.conf:
+    content: |
+      local all         all         trust
+      host  all         all all     scram-sha-256
+      host  replication all all     scram-sha-256
+
+  seaweedfs-s3.json:
+    content: |
+      {"identities":[{"name":"pgrwl","credentials":[{"accessKey":"pgrwl","secretKey":"pgrwl-secret"}],"actions":["Admin","Read","Write","List","Tagging"]}]}
+
+  pgrwl-config.yaml:
+    content: |
+      main:
+        listen_port: 7070
+        directory: "/mnt/wal-archive"
+      receiver:
+        slot: pgrwl_dr
+        uploader:
+          sync_interval: 10s
+          max_concurrency: 4
+        retention:
+          enable: false      # keep every backup while you experiment; production sets a recovery window
+      backup:
+        cron: "0 * * * *"    # hourly; the guide takes backups by hand with scripts/01-backup.sh
+      log:
+        level: info
+        format: text
+      storage:
+        name: s3
+        compression:
+          algo: gzip
+        encryption:
+          algo: aes-256-gcm
+          pass: change-me-in-production
+        s3:
+          url: http://seaweedfs:8333
+          access_key_id: pgrwl
+          secret_access_key: pgrwl-secret
+          bucket: backups
+          region: us-east-1
+          use_path_style: true
+          disable_ssl: true
+
+  restore.sh:
+    file: ./restore.sh

--- a/examples/production-dr/restore.sh
+++ b/examples/production-dr/restore.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+# Runs once inside the pg-restore container (see docker-compose.yml). PGDATA must be empty.
+#
+#   RESTORE_ID            base backup id (UTC, YYYYMMDDHHMMSS); empty = latest
+#   RECOVERY_TARGET_TIME  PostgreSQL timestamp, e.g. 2026-09-09 10:15:30.123456+00; empty = end of WAL
+set -euo pipefail
+PGDATA=/var/lib/postgresql/data
+CONFIG=/etc/pgrwl-config.yaml
+
+if [ -n "$(ls -A "$PGDATA")" ]; then
+  echo "refusing to restore: $PGDATA is not empty" >&2
+  exit 1
+fi
+
+echo ">> pulling base backup ${RESTORE_ID:-latest} into $PGDATA"
+pgrwl restore -c "$CONFIG" --dest="$PGDATA" ${RESTORE_ID:+--id="$RESTORE_ID"}
+
+echo ">> writing recovery settings"
+touch "$PGDATA/recovery.signal"
+{
+  echo "restore_command = 'pgrwl restore-command --serve-addr=pgrwl-serve:7070 %f %p'"
+  if [ -n "${RECOVERY_TARGET_TIME:-}" ]; then
+    echo "recovery_target_time = '${RECOVERY_TARGET_TIME}'"
+    echo "recovery_target_action = 'promote'"
+  fi
+} > "$PGDATA/postgresql.auto.conf"
+cat "$PGDATA/postgresql.auto.conf"
+
+chown -R postgres:postgres "$PGDATA"
+chmod 0700 "$PGDATA"
+echo ">> done; start pg-primary to begin recovery"

--- a/examples/production-dr/scripts/01-backup.sh
+++ b/examples/production-dr/scripts/01-backup.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+# Take a base backup with pgrwl (streaming replication protocol, no pg_basebackup).
+# The receiver keeps streaming WAL while the backup runs; the replication slot
+# guarantees that every WAL record after the backup's start LSN is retained.
+source "$(dirname "$0")/lib.sh"
+
+log "taking base backup"
+$COMPOSE exec -T pgrwl-receive pgrwl backup -c /etc/pgrwl-config.yaml
+
+log "backups known to the receiver"
+list_backups; echo

--- a/examples/production-dr/scripts/02-workload.sh
+++ b/examples/production-dr/scripts/02-workload.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+# Write one timestamped row per second so that every restore can be checked
+# against a known last row. Default: 30 seconds.
+source "$(dirname "$0")/lib.sh"
+SECONDS_TO_RUN="${1:-30}"
+
+psql_primary -c "create table if not exists dr_events (id bigserial primary key, ts timestamptz not null default now(), note text);"
+log "inserting one row per second for ${SECONDS_TO_RUN}s"
+for _ in $(seq 1 "$SECONDS_TO_RUN"); do
+  psql_primary -c "insert into dr_events(note) values ('tick');"
+  sleep 1
+done
+log "dr_events now: $(psql_primary -c "select count(*) || ' rows, last ts ' || max(ts) from dr_events")"

--- a/examples/production-dr/scripts/03-accident.sh
+++ b/examples/production-dr/scripts/03-accident.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+# The "oops" moment: record the time T just before the damage, then DROP TABLE.
+# T is printed in UTC with microseconds in PostgreSQL's own format; 05-restore-pitr.sh takes it as-is.
+source "$(dirname "$0")/lib.sh"
+
+T="$(psql_primary -c "select to_char(now() at time zone 'UTC', 'YYYY-MM-DD HH24:MI:SS.US+00')")"
+ROWS="$(psql_primary -c 'select count(*) from dr_events')"
+sleep 1
+psql_primary -c "drop table dr_events;"
+
+log "T = ${T}  (dr_events had ${ROWS} rows at T; the table is gone now)"
+echo "$T" > .last-accident-time
+echo
+echo "Next: scripts/05-restore-pitr.sh \"${T}\""

--- a/examples/production-dr/scripts/04-restore-latest.sh
+++ b/examples/production-dr/scripts/04-restore-latest.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# Scenario A: PGDATA is lost. Restore the latest base backup and replay all WAL.
+#
+#   1. stop PostgreSQL and the receiver, delete the data volume (the disaster)
+#   2. start pgrwl in serve mode (WAL source for restore_command)
+#   3. pg-restore: pull the base backup into an empty PGDATA, write recovery settings
+#   4. start PostgreSQL; it replays WAL until the archive ends, then promotes
+#   5. start the receiver again; it follows the new timeline
+source "$(dirname "$0")/lib.sh"
+export RESTORE_ID="${RESTORE_ID:-}" RECOVERY_TARGET_TIME=""
+
+log "1/5 stopping pg-primary and pgrwl-receive, deleting volume ${PG_VOLUME}"
+$COMPOSE stop pgrwl-receive pg-primary
+$COMPOSE rm -f pg-primary
+docker volume rm "$PG_VOLUME"
+T0=$(date +%s)
+
+log "2/5 starting pgrwl-serve"
+$COMPOSE --profile restore up -d pgrwl-serve
+
+log "3/5 restoring base backup ${RESTORE_ID:-latest} into a fresh PGDATA"
+$COMPOSE --profile restore run --rm pg-restore
+
+log "4/5 starting pg-primary (archive recovery)"
+$COMPOSE up -d pg-primary
+wait_out_of_recovery
+T1=$(date +%s)
+
+log "5/5 starting pgrwl-receive again, stopping pgrwl-serve"
+$COMPOSE up -d --no-deps pgrwl-receive
+$COMPOSE --profile restore stop pgrwl-serve
+
+log "recovered to timeline $(psql_primary -c 'select timeline_id from pg_control_checkpoint()') in $((T1 - T0))s"
+log "dr_events: $(psql_primary -c "select count(*) || ' rows, last ts ' || max(ts) from dr_events")"
+echo
+echo "Next: take a fresh base backup on the new timeline: scripts/01-backup.sh"

--- a/examples/production-dr/scripts/05-restore-pitr.sh
+++ b/examples/production-dr/scripts/05-restore-pitr.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+# Scenario B: point-in-time recovery to a moment before the accident.
+#
+#   usage: scripts/05-restore-pitr.sh <T> [backup-id]
+#     T           target time as printed by 03-accident.sh: 'YYYY-MM-DD HH:MM:SS.US+00' (UTC)
+#     backup-id   base backup to start from; default: newest backup that finished before T
+#
+# Steps are the same as 04-restore-latest.sh, plus recovery_target_time.
+source "$(dirname "$0")/lib.sh"
+T="${1:?target time required, e.g. '2026-09-09 10:15:30.123456+00'}"
+ID="${2:-}"
+
+if [ -z "$ID" ]; then
+  # newest completed backup whose "finished" precedes T
+  # (API gives RFC-3339 UTC "2026-09-09T10:15:30.1Z"; rewrite it as "2026-09-09 10:15:30.1+00" so a string compare with T works)
+  ID="$(list_backups | tr '{' '\n' | grep '"status":"completed"' \
+        | sed -n 's/.*"label":"pgrwl_\([0-9]*\)".*"finished":"\([^"]*\)".*/\2 \1/p' \
+        | sed 's/T/ /; s/Z /+00 /' \
+        | awk -F'  *' -v t="$T" '$1" "$2 < t {print $3}' | sort -r | head -1)"
+  case "$T" in *+00) ;; *) echo "note: automatic backup selection assumes T is UTC (+00); pass the backup id explicitly otherwise" >&2 ;; esac
+  [ -n "$ID" ] || { echo "no completed base backup finished before $T" >&2; exit 1; }
+fi
+export RESTORE_ID="$ID" RECOVERY_TARGET_TIME="$T"
+
+log "1/5 stopping pg-primary and pgrwl-receive, deleting volume ${PG_VOLUME}"
+$COMPOSE stop pgrwl-receive pg-primary
+$COMPOSE rm -f pg-primary
+docker volume rm "$PG_VOLUME"
+T0=$(date +%s)
+
+log "2/5 starting pgrwl-serve"
+$COMPOSE --profile restore up -d pgrwl-serve
+
+log "3/5 restoring base backup ${ID}, target time ${T}"
+$COMPOSE --profile restore run --rm pg-restore
+
+log "4/5 starting pg-primary (archive recovery up to T, then promote)"
+$COMPOSE up -d pg-primary
+wait_out_of_recovery
+T1=$(date +%s)
+
+log "5/5 starting pgrwl-receive again, stopping pgrwl-serve"
+$COMPOSE up -d --no-deps pgrwl-receive
+$COMPOSE --profile restore stop pgrwl-serve
+
+log "recovered to timeline $(psql_primary -c 'select timeline_id from pg_control_checkpoint()') in $((T1 - T0))s"
+log "dr_events: $(psql_primary -c "select count(*) || ' rows, last ts ' || max(ts) from dr_events")"
+log "rows after T (must be 0): $(psql_primary -c "select count(*) from dr_events where ts > '${T}'")"
+echo
+echo "Next: take a fresh base backup on the new timeline: scripts/01-backup.sh"

--- a/examples/production-dr/scripts/lib.sh
+++ b/examples/production-dr/scripts/lib.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+# Shared helpers for the production-dr scripts. Sourced, not executed.
+set -euo pipefail
+cd "$(dirname "${BASH_SOURCE[0]}")/.."
+
+COMPOSE="docker compose"
+PROJECT="${COMPOSE_PROJECT_NAME:-$(basename "$PWD")}"   # compose project name defaults to the directory name
+# shellcheck disable=SC2034  # used by the restore scripts
+PG_VOLUME="${PROJECT}_pg-data"
+PGRWL_API="http://localhost:7070"
+
+psql_primary() { $COMPOSE exec -T pg-primary psql -U postgres -v ON_ERROR_STOP=1 -Atq "$@"; }
+log()          { printf '\n[%s] %s\n' "$(date -u '+%H:%M:%S')" "$*"; }
+
+# Waits until PostgreSQL is up and out of recovery. Connection errors while it is
+# still starting or replaying are expected; a restarting container is not.
+wait_out_of_recovery() {
+  for _ in $(seq 1 600); do
+    if [ "$(psql_primary -c 'select pg_is_in_recovery()' 2>/dev/null || true)" = "f" ]; then return 0; fi
+    # a container that keeps restarting means PostgreSQL refused its configuration
+    if [ "$(docker inspect -f '{{.RestartCount}}' pg-primary 2>/dev/null || echo 0)" -gt 0 ]; then
+      echo "PostgreSQL failed to start:" >&2; docker logs --tail 8 pg-primary >&2; return 1
+    fi
+    sleep 1
+  done
+  echo "PostgreSQL did not finish recovery in 600s; check: $COMPOSE logs pg-primary pgrwl-serve" >&2
+  return 1
+}
+
+list_backups() { curl -sf "$PGRWL_API/api/v1/backups"; }


### PR DESCRIPTION
## Description

Adds `examples/production-dr/`, the guide discussed in #213: a compose setup with PostgreSQL 17, `pgrwl` and SeaweedFS, plus five numbered scripts that rehearse two recoveries end to end.

- Scenario A (`04-restore-latest.sh`): the data volume is deleted, the newest base backup is restored and all WAL replayed.
- Scenario B (`05-restore-pitr.sh`): `03-accident.sh` records T and drops a table; recovery stops just before that transaction. The base backup is picked automatically (newest whose `finished` precedes T, from `/api/v1/backups`) or given explicitly.

Design choices, following your notes:

- Only `pgrwl` commands: `pgrwl backup`, `pgrwl restore`, serve mode and `pgrwl restore-command`. No `pg_basebackup`, no `.partial` renaming.
- Restore is one short script (`restore.sh`) in a one-shot container that shares the data volume: base backup into empty PGDATA, `recovery.signal`, `postgresql.auto.conf`. The compose-specific part ends there; the README maps every step onto a VM.
- Four containers in normal operation, two more only under the `restore` profile. SeaweedFS config taken from the root `docker-compose.yml`.
- The image for `pg-primary` is `postgres:17.9-bookworm` plus the pgrwl binary from the release tarball for the container's architecture (`TARGETARCH`), so it builds on amd64 and arm64.
- README is written as the procedure, not as PITR internals. It also states what happens on the new timeline (the receiver follows it and recreates the slot) and what is lost when the receiver host dies together with the database.

## How it was tested

Clean run from `docker compose down -v` in README order on Docker 28 / Compose 2.39 (arm64 host, Rosetta for the pgrwl image): both scenarios pass in about a minute total, recovery itself takes ~2 s on the demo data.

- Scenario A: 10 rows before, 10 after, timeline 2, receiver logs `end of timeline, continue`.
- Scenario B: 20 rows at T, table back with 20 rows, 0 rows after T, PostgreSQL logs `recovery stopping before commit of transaction N`, timeline 3.
- Receiver-host loss (README section 5): receiver volume removed together with PGDATA; recovery from S3 alone restored everything up to the last completed segment and lost exactly the rows written into the open segment (5 of 65 in the rehearsal).

Two things I noticed on the way, outside this PR's scope; happy to open issues if useful:

- `quay.io/pgrwl/pgrwl` is published for amd64 only while the release tarballs include arm64; a multi-arch image would let the example run on Apple Silicon without the `platform:` override.
- In `docker-compose-recovery-example`, renaming `*.partial` to full segment names makes the receiver unable to resume after a restore (it asks for the next segment on the old timeline). Serve mode already handles `.partial` files, so the rename is not needed.

Fixes #213
